### PR TITLE
Pull magic value regular expressions out into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,13 @@ var unlicensed = {
 assert.deepEqual(valid('UNLICENSED'), unlicensed);
 assert.deepEqual(valid('UNLICENCED'), unlicensed);
 ```
+
+Regular expressions for `SEE LICENSE IN...` and `UNLICENSED` magic values are exported as separate modules:
+
+```javascript
+var seeRE = require('validate-npm-package-license/see-license-in')
+assert(seeRE instanceof RegExp)
+
+var unRE = require('validate-npm-package-license/unlicensed')
+assert(unRE  instanceof RegExp)
+```

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var genericWarning = (
   '"SEE LICENSE IN <filename>"'
 );
 
-var fileReferenceRE = /^SEE LICEN[CS]E IN (.+)$/;
+var fileReferenceRE = require('./see-license-in')
 
 function startsWith(prefix, string) {
   return string.slice(0, prefix.length) === prefix;
@@ -29,6 +29,8 @@ function usesLicenseRef(ast) {
   }
 }
 
+var unlicensedRE = require('./unlicensed')
+
 module.exports = function(argument) {
   var ast;
 
@@ -36,10 +38,7 @@ module.exports = function(argument) {
     ast = parse(argument);
   } catch (e) {
     var match
-    if (
-      argument === 'UNLICENSED' ||
-      argument === 'UNLICENCED'
-    ) {
+    if (unlicensedRE.test(argument)) {
       return {
         validForOldPackages: true,
         validForNewPackages: true,

--- a/see-license-in.js
+++ b/see-license-in.js
@@ -1,0 +1,2 @@
+module.exports = /^SEE LICEN[CS]E IN (.+)$/;
+

--- a/unlicensed.js
+++ b/unlicensed.js
@@ -1,0 +1,1 @@
+module.exports = /^(UNLICENSED|UNLICENCED)$/;


### PR DESCRIPTION
@othiym23: This would be a semver-minor release for newly exposed API. The idea here is to make it possible to `require()` just the regular expressions for values like `SEE LICENSE IN LICENSE.md` and `UNLICENSED`. Those are npm-specific magic values, so they seem to belong in an npm-specific package.

I'd end up using these in npm/newww#996
