### PR TITLE
Upgrade SPDX tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SPDX expressions are valid, too ...
 ```javascript
 // Simple SPDX license expression for dual licensing
 assert.deepEqual(
-  valid('(GPL-3.0 OR BSD-2-Clause)'),
+  valid('(GPL-3.0-only OR BSD-2-Clause)'),
   validSPDXExpression
 );
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,17 @@
       "requires": {
         "spdx-expression-parse": "2.0.2",
         "spdx-license-ids": "2.0.1"
+      },
+      "dependencies": {
+        "spdx-expression-parse": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz",
+          "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "2.0.1"
+          }
+        }
       }
     },
     "spdx-exceptions": {
@@ -85,12 +96,19 @@
       "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
     },
     "spdx-expression-parse": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-2.0.2.tgz",
-      "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
         "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "2.0.1"
+        "spdx-license-ids": "3.0.0"
+      },
+      "dependencies": {
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+        }
       }
     },
     "spdx-license-ids": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,11 +71,12 @@
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-2.0.4.tgz",
+      "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "2.0.2",
+        "spdx-license-ids": "2.0.1"
       }
     },
     "spdx-exceptions": {
@@ -89,13 +90,13 @@
       "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
       "requires": {
         "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "2.0.1"
       }
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-2.0.1.tgz",
+      "integrity": "sha1-AgF7zDU07k/+9tWNIOfT6aHDyOw="
     },
     "stream-replace": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.0.1",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
   "dependencies": {
-    "spdx-correct": "~1.0.0",
+    "spdx-correct": "^2.0.4",
     "spdx-expression-parse": "^2.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com)",
   "dependencies": {
     "spdx-correct": "^2.0.4",
-    "spdx-expression-parse": "^2.0.2"
+    "spdx-expression-parse": "^3.0.0"
   },
   "devDependencies": {
     "defence-cli": "^2.0.1",


### PR DESCRIPTION
@zkat: Upgrading this package, primarily through its dependencies.  Long story short, `spdx-expression-parse` used to essentially bundle `spdx-license-ids` and `spdx-exceptions`, which are lists of identifiers that get updated fairly often, as SPDX standardizes more licenses.  As of `spdx-expression-parse@2.0.0`, those packages are now regular `dependencies`, which means the SPDX expression parser gets "upgraded" with new package lists whenever they're published, rather than waiting on me to republish-rebundle.

It's one of those gray areas, but I believe this can go out semver-patch.  That would make it v3.0.2, IIRC.

I'm not sure what the process for requesting a bump in npm CLI is these days.  Do I send you a pull request?  Looks like the old `./scripts/update-dep` hasn't been used of late.

The effect on npm should be neutral to good.  This package now has a slightly larger dependency tree, but those packages will be deduped with `spdx-correct`, anyway.  The old parser used to bundle redundant text lists, but won't any longer.  If folks get npm's deps by dynamic install, they'll also see license metadata validation errors go away for newly-approved licenses.  Should be good.

Many thanks!