### PR TITLE
Handle empty or whitespace-only input

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,11 +57,13 @@ module.exports = function(argument) {
         validForNewPackages: false,
         warnings: [genericWarning]
       };
-      var corrected = correct(argument);
-      if (corrected) {
-        result.warnings.push(
-          'license is similar to the valid expression "' + corrected + '"'
-        );
+      if (argument.trim().length !== 0) {
+        var corrected = correct(argument);
+        if (corrected) {
+          result.warnings.push(
+            'license is similar to the valid expression "' + corrected + '"'
+          );
+        }
       }
       return result;
     }


### PR DESCRIPTION
When given an empty or whitespace-only string, the `spdx-correct` check
is skipped. There is no point in looking for similar licences in this
case.

Closes #8