### PR TITLE
Update README.md to include copyright notice - Important for consuming Apache licensed libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ var unlicensed = {
 assert.deepEqual(valid('UNLICENSED'), unlicensed);
 assert.deepEqual(valid('UNLICENCED'), unlicensed);
 ```
+
+License
+=======
+Copyright 2019 Kyle Mitchell <kyle@kemitchell.com>


### PR DESCRIPTION
Apache license needs the consuming packages to provide attributions to the original owner. I could not locate copyright statement in the repository. So adding this line so that we can provide the attributions when some of the consuming packages are used by applications.

==============
We are trying to use eslint-plugin-unicorn which uses this internally. Please review and approve.